### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/gym-management-sys-back/src/main/java/gr/digital/systems/gym/management/back/config/SecurityConfig.java
+++ b/gym-management-sys-back/src/main/java/gr/digital/systems/gym/management/back/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
-		http.csrf(AbstractHttpConfigurer::disable)
+		http
 				.cors(Customizer.withDefaults())
 				.authorizeHttpRequests(
 						auth ->


### PR DESCRIPTION
Potential fix for [https://github.com/GiorgosThf/gym-management-sys/security/code-scanning/1](https://github.com/GiorgosThf/gym-management-sys/security/code-scanning/1)

**General Fix:**  
Rather than disabling CSRF protection globally, keep CSRF protection enabled by default. For pure stateless APIs (which use JWT and never rely on session or cookie-based authentication), it is safe to selectively disable CSRF for specific endpoints, typically only those that are public and cannot mutate application state, or for endpoints where you’re sure CSRF is not relevant.

**Detailed Fix:**  
- Remove or modify the call to `http.csrf(AbstractHttpConfigurer::disable)`.
- By default, Spring Security will then enforce CSRF protections on non-GET, non-HEAD, non-OPTIONS requests.
- If you are using JWT tokens *and* do not use cookies for authentication, you may want to selectively disable CSRF for your API endpoints (e.g., using `csrf().ignoringRequestMatchers("/api/**")`), but be very careful and only do so if you are sure it's safe.
- In this case, since the application uses JWTs and seems stateless, but we cannot verify that *all* endpoints are protected appropriately, the best fix in the shown code is simply to remove or comment out the `.csrf(AbstractHttpConfigurer::disable)` line and use the framework defaults.

**Lines to modify:**  
In `SecurityConfig.java` (lines 49), remove `.csrf(AbstractHttpConfigurer::disable)`.

**Imports:**  
No imports need to be added or removed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
